### PR TITLE
Upgrade to latest checkout action

### DIFF
--- a/.github/workflows/validate-md.yml
+++ b/.github/workflows/validate-md.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         
       # Runs a set of commands using the runners shell
       - name: Check Markdown Files


### PR DESCRIPTION
Fixes a warning in GitHub Actions: https://github.com/bountonw/translate/actions/runs/7650835978

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. ...