### PR TITLE
Add basic CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Catch-all owners for everything not specified below.
+* @bountonw @deadpikle @mattleff
+
+*.lua @mattleff
+*.sh @mattleff
+
+/.github/ @bountonw
+*.md @bountonw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Catch-all owners for everything not specified below.
+# @src https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 * @bountonw @deadpikle @mattleff
 
 *.lua @mattleff


### PR DESCRIPTION
This adds a basic code owners file. You can turn on requiring a review from the code owners for the changed files on a PR in the [settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection) for the repo.

Refs #43.