### PR TITLE
Allow trailing punctuation in headings

### DIFF
--- a/.tooling/markdownlint/config-draft.markdownlint-cli2.cjs
+++ b/.tooling/markdownlint/config-draft.markdownlint-cli2.cjs
@@ -5,6 +5,7 @@ module.exports = {
     "no-bare-urls": false,
     "no-duplicate-heading": false,
     "no-inline-html": false,
+    "no-trailing-punctuation": false,
     "single-trailing-newline": false,
     "heading-style": {
       style: "atx",


### PR DESCRIPTION
Refs some of the linting failures in #52. This changes allows trailing punctuation (such as `".!?`, etc.) in headings like this:

```md
### “He opened His mouth, and taught them, saying, Blessed are the poor in spirit: for theirs is the kingdom of heaven.”—Matthew 5:2, 3.
```