### PR TITLE
Exclude PDF generation for non-Thai sources

### DIFF
--- a/.tooling/latex/draftall.sh
+++ b/.tooling/latex/draftall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-(cd ../../ && find . -path "*/02_edit/*" -or -path "*/03_public/*" -not -path "*/.tooling/*" -name "*.md") | while read LINE;
+(cd ../../ && find . -path "*/th/*/02_edit/*" -or -path "*/th/*/03_public/*" -not -path "*/.tooling/*" -name "*.md") | while read LINE;
 do
     f="$(echo $LINE | cut -c 3-)"
     if [[ "$f" == *".md" ]];then


### PR DESCRIPTION
Should fix the build issue on #89. We can't build Lao PDFs yet because we're defining a Thai font for all PDFs atm...