### PR TITLE
Fix error with container-based CI runs

### DIFF
--- a/.github/workflows/generate-icml.yml
+++ b/.github/workflows/generate-icml.yml
@@ -26,7 +26,9 @@ jobs:
       matrix:
         book: ['th/PP/PP1', 'th/PP/PP2', 'th/PP/PP3', 'th/PP/PP4','th/PP/PP5', 'th/MB', 'th/LBF']
     runs-on: ubuntu-20.04
-    container: mattleff/xelatex-swath
+    container:
+      image: mattleff/xelatex-swath
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -26,7 +26,9 @@ jobs:
       matrix:
         book: ['th/PP/PP1', 'th/PP/PP2', 'th/PP/PP3', 'th/PP/PP4','th/PP/PP5', 'th/MB', 'th/LBF']
     runs-on: ubuntu-20.04
-    container: mattleff/xelatex-swath
+    container:
+      image: mattleff/xelatex-swath
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Uses a technique documented at https://github.com/actions/runner/issues/2033#issuecomment-1598547465 to run the CI jobs as the `runner` user to fix a log error.