### PR TITLE
Attempt to generate fewer PDFs

### DIFF
--- a/.github/workflows/generate-icml.yml
+++ b/.github/workflows/generate-icml.yml
@@ -21,10 +21,46 @@ defaults:
     shell: bash
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    outputs:
+      # Expose matched filters as job 'books' output variable
+      books: ${{ steps.filter.outputs.changes }}
+    steps:
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          th/PP/PP1:
+            - 'th/PP/PP1/**'
+            - .tooling
+          th/PP/PP2:
+            - 'th/PP/PP2/**'
+            - .tooling
+          th/PP/PP3:
+            - 'th/PP/PP3/**'
+            - .tooling
+          th/PP/PP4:
+            - 'th/PP/PP4/**'
+            - .tooling
+          th/PP/PP5:
+            - 'th/PP/PP5/**'
+            - .tooling
+          th/MB:
+            - 'th/MB/**'
+            - .tooling
+          th/LBF:
+            - 'th/LBF/**'
+            - .tooling
+
   generate-icmls:
+    needs: changes
     strategy:
       matrix:
-        book: ['th/PP/PP1', 'th/PP/PP2', 'th/PP/PP3', 'th/PP/PP4','th/PP/PP5', 'th/MB', 'th/LBF']
+        book: ${{ contains('main', github.ref_name) && '["th/PP/PP1", "th/PP/PP2", "th/PP/PP3", "th/PP/PP4", "th/PP/PP5", "th/LBF", "th/MB"]' || fromJSON(needs.changes.outputs.books) }}
     runs-on: ubuntu-20.04
     container:
       image: mattleff/xelatex-swath

--- a/.github/workflows/generate-icml.yml
+++ b/.github/workflows/generate-icml.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: 'recursive'
       - name: Generate ICMLs
         working-directory: ./.tooling/latex/
-        run: ./generate-icmls.sh ${{ matrix.book }}
+        run: make -j 4 icmls/${{ matrix.book }}
       # Dynamically set the name for the artifact based on the current time and build scope
       - name: Set Env
         run: |

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -60,7 +60,7 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        package: ${{ fromJSON(needs.changes.outputs.packages) }}
+        book: ${{ fromJSON(needs.changes.outputs.packages) }}
     runs-on: ubuntu-20.04
     container:
       image: mattleff/xelatex-swath

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -72,7 +72,7 @@ jobs:
           submodules: 'recursive'
       - name: Run Make
         working-directory: ./.tooling/latex/
-        run: ./draft.sh ${{ matrix.book }}
+        run: make -j 4 pdfs/${{ matrix.book }}
       # Dynamically set the name for the artifact based on the current time and build scope
       - name: Set Env
         run: |

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -30,7 +30,7 @@ jobs:
       # Expose matched filters as job 'packages' output variable
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-    # For pull requests it's not necessary to checkout the code
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -27,8 +27,8 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      # Expose matched filters as job 'packages' output variable
-      packages: ${{ steps.filter.outputs.changes }}
+      # Expose matched filters as job 'books' output variable
+      books: ${{ steps.filter.outputs.changes }}
     steps:
     - uses: dorny/paths-filter@v3
       id: filter
@@ -60,7 +60,7 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        book: ${{ fromJSON(needs.changes.outputs.packages) }}
+        book: ${{ contains('main', github.ref_name) && '["th/PP/PP1", "th/PP/PP2", "th/PP/PP3", "th/PP/PP4", "th/PP/PP5", "th/LBF", "th/MB"]' || fromJSON(needs.changes.outputs.books) }}
     runs-on: ubuntu-20.04
     container:
       image: mattleff/xelatex-swath

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -21,10 +21,33 @@ defaults:
     shell: bash
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    outputs:
+      # Expose matched filters as job 'packages' output variable
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          th/PP/PP1: th/PP/PP1
+          th/PP/PP2: th/PP/PP2
+          th/PP/PP3: th/PP/PP3
+          th/PP/PP4: th/PP/PP4
+          th/PP/PP5: th/PP/PP5
+          th/MB: th/MB
+          th/LBF: th/LBF
+
   generate-pdfs:
+    needs: changes
     strategy:
       matrix:
-        book: ['th/PP/PP1', 'th/PP/PP2', 'th/PP/PP3', 'th/PP/PP4','th/PP/PP5', 'th/MB', 'th/LBF']
+        package: ${{ fromJSON(needs.changes.outputs.packages) }}
     runs-on: ubuntu-20.04
     container:
       image: mattleff/xelatex-swath

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -30,18 +30,24 @@ jobs:
       # Expose matched filters as job 'packages' output variable
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
-          th/PP/PP1: th/PP/PP1
-          th/PP/PP2: th/PP/PP2
-          th/PP/PP3: th/PP/PP3
-          th/PP/PP4: th/PP/PP4
-          th/PP/PP5: th/PP/PP5
-          th/MB: th/MB
-          th/LBF: th/LBF
+          th/PP/PP1:
+            - 'th/PP/PP1/**'
+          th/PP/PP2:
+            - 'th/PP/PP2/**'
+          th/PP/PP3:
+            - 'th/PP/PP3/**'
+          th/PP/PP4:
+            - 'th/PP/PP4/**'
+          th/PP/PP5:
+            - 'th/PP/PP5/**'
+          th/MB:
+            - 'th/MB/**'
+          th/LBF:
+            - 'th/LBF/**'
 
   generate-pdfs:
     needs: changes

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -36,18 +36,25 @@ jobs:
         filters: |
           th/PP/PP1:
             - 'th/PP/PP1/**'
+            - .tooling
           th/PP/PP2:
             - 'th/PP/PP2/**'
+            - .tooling
           th/PP/PP3:
             - 'th/PP/PP3/**'
+            - .tooling
           th/PP/PP4:
             - 'th/PP/PP4/**'
+            - .tooling
           th/PP/PP5:
             - 'th/PP/PP5/**'
+            - .tooling
           th/MB:
             - 'th/MB/**'
+            - .tooling
           th/LBF:
             - 'th/LBF/**'
+            - .tooling
 
   generate-pdfs:
     needs: changes

--- a/th/PP/PP5/02_edit/PP65_th.md
+++ b/th/PP/PP5/02_edit/PP65_th.md
@@ -3,7 +3,7 @@ chapter:
   number: 65
   title:
     th: ดาวิดใจกว้าง
-    en: The Magnanimity of David!
+    en: The Magnanimity of David
   url: https://legacy.egwwritings.org/?ref=en_PP.660&para=84.3100
   basedon: ศึกษาควบคู่กับ 1 ซามูเอล บทที่ 22:20–23; 23–27
 ---

--- a/th/PP/PP5/02_edit/PP65_th.md
+++ b/th/PP/PP5/02_edit/PP65_th.md
@@ -3,7 +3,7 @@ chapter:
   number: 65
   title:
     th: ดาวิดใจกว้าง
-    en: The Magnanimity of David
+    en: The Magnanimity of David!
   url: https://legacy.egwwritings.org/?ref=en_PP.660&para=84.3100
   basedon: ศึกษาควบคู่กับ 1 ซามูเอล บทที่ 22:20–23; 23–27
 ---


### PR DESCRIPTION
Fixes https://github.com/bountonw/translate-tooling/issues/46. This should handle both limiting the number of jobs run to only those with changed files (unless the `.tooling` changes, in which case it runs everything), and it also adds support for running Make tasks in parallel (https://github.com/bountonw/translate-tooling/pull/51). The latter improvement reduces all generation time significantly. For example, the LBF PDF generation time is around 50% less. 