### PR TITLE
Add --use-existing-tex-files to skip module1/2 in make_book.sh

### DIFF
--- a/lo/GC/04_assets/scripts/make_book.sh
+++ b/lo/GC/04_assets/scripts/make_book.sh
@@ -18,7 +18,7 @@ while test $# -gt 0; do
   esac
 done
 
-CHAP_NUM=2 # set to 42 for full book or a small number for testing
+CHAP_NUM=42 # set to 42 for full book or a small number for testing
 if [ "${use_existing_tex_files}" = false ]
 then
     for ((i=1;i<=CHAP_NUM;i++)); do


### PR DESCRIPTION
Run `scripts/make_book.sh --use-existing-tex-files` to skip the first `make_book.sh` step that re-creates every chapter. 

Still runs module3 to generate the overall tex file, then `lualatex` to generate the PDF. Still verifies that all chapter tex files are there. If you need to rebuild a specific chapter and not the whole book, use `make_pdf.sh` instead to rebuild that one chapter's files, then rerun `make_book.sh` as needed.

Closes #661
